### PR TITLE
Document possible values with their type

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Possible values:
 
 - **`PropRenderer.Text`** - render post excerpts as simple text, no HTML entities supported,
 
-- `PropRenderer.Html` - render post excerpts as HTML, HTML entities supported,
+- **`PropRenderer.Html`** - render post excerpts as HTML, HTML entities supported,
 
 - **`PropRenderer.Hybrid`** - render post excerpts as simple text but allow HTML entities as well.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ renderer?: PropRenderer
 
 Possible values:
 
-- `PropRenderer.Text` - render post excerpts as simple text, no HTML entities supported,
+- **`PropRenderer.Text`** - render post excerpts as simple text, no HTML entities supported,
 
 - `PropRenderer.Html` - render post excerpts as HTML, HTML entities supported,
 

--- a/README.md
+++ b/README.md
@@ -220,11 +220,11 @@ headings?: PropHeadings
 
 Possible values:
 
-- `Intact` - leave the headings intact,
+- `PropHeadings.Intact` - leave the headings intact,
 
-- `TextOnly` - remove Markdown code but keep the headings text,
+- `PropHeadings.TextOnly` - remove Markdown code but keep the headings text,
 
-- `None` - remove the headings completely.
+- `PropHeadings.None` - remove the headings completely.
 
 <br>
 
@@ -244,11 +244,11 @@ renderer?: PropRenderer
 
 Possible values:
 
-- `Text` - render post excerpts as simple text, no HTML entities supported,
+- `PropRenderer.Text` - render post excerpts as simple text, no HTML entities supported,
 
-- `Html` - render post excerpts as HTML, HTML entities supported,
+- `PropRenderer.Html` - render post excerpts as HTML, HTML entities supported,
 
-- `Hybrid` - render post excerpts as simple text but allow HTML entities as well.
+- `PropRenderer.Hybrid` - render post excerpts as simple text but allow HTML entities as well.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ headings?: PropHeadings
 
 Possible values:
 
-- `PropHeadings.Intact` - leave the headings intact,
+- **`PropHeadings.Intact`** - leave the headings intact,
 
 - `PropHeadings.TextOnly` - remove Markdown code but keep the headings text,
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Possible values:
 
 - **`PropHeadings.TextOnly`** - remove Markdown code but keep the headings text,
 
-- `PropHeadings.None` - remove the headings completely.
+- **`PropHeadings.None`** - remove the headings completely.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Possible values:
 
 - **`PropHeadings.Intact`** - leave the headings intact,
 
-- `PropHeadings.TextOnly` - remove Markdown code but keep the headings text,
+- **`PropHeadings.TextOnly`** - remove Markdown code but keep the headings text,
 
 - `PropHeadings.None` - remove the headings completely.
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Possible values:
 
 - `PropRenderer.Html` - render post excerpts as HTML, HTML entities supported,
 
-- `PropRenderer.Hybrid` - render post excerpts as simple text but allow HTML entities as well.
+- **`PropRenderer.Hybrid`** - render post excerpts as simple text but allow HTML entities as well.
 
 <br>
 


### PR DESCRIPTION
Hey Igor, I like your `PostExcerpt` component but by going through the readme I thought I can use it like this:

```jsx
<PostExcerpt post={post} words={50} smartEllipsis={true} renderer={'Html'} />
```

Instead I had to use:

```jsx
<PostExcerpt post={post} words={50} smartEllipsis={true} renderer={PropRenderer.Html} />
```

With an import like this:

```
import PostExcerpt, {PropRenderer} from '@igor.dvlpr/astro-post-excerpt'
```

Which is why I think explicitly listing the possible values make sense. WDYT?